### PR TITLE
Support arrays

### DIFF
--- a/copilot-verifier/copilot-verifier.cabal
+++ b/copilot-verifier/copilot-verifier.cabal
@@ -46,6 +46,7 @@ common bldflags
     prettyprinter >= 1.7.0,
     text,
     transformers,
+    vector,
     what4 >= 0.4
 
 library
@@ -64,6 +65,7 @@ library copilot-verifier-examples
     copilot-verifier
   exposed-modules:
     Copilot.Verifier.Examples
+    Copilot.Verifier.Examples.Array
     Copilot.Verifier.Examples.Arith
     Copilot.Verifier.Examples.Clock
     Copilot.Verifier.Examples.Counter

--- a/copilot-verifier/examples/Copilot/Verifier/Examples.hs
+++ b/copilot-verifier/examples/Copilot/Verifier/Examples.hs
@@ -7,6 +7,7 @@ import qualified Data.Map as Map
 import Data.Map (Map)
 import Data.Text (Text)
 
+import qualified Copilot.Verifier.Examples.Array   as Array
 import qualified Copilot.Verifier.Examples.Arith   as Arith
 import qualified Copilot.Verifier.Examples.Clock   as Clock
 import qualified Copilot.Verifier.Examples.Counter as Counter
@@ -16,7 +17,8 @@ import qualified Copilot.Verifier.Examples.Voting  as Voting
 
 allExamples :: Map (CI Text) (IO ())
 allExamples = Map.fromList
-    [ example "Arith" Arith.main
+    [ example "Array" Array.main
+    , example "Arith" Arith.main
     , example "Clock" Clock.main
     , example "Counter" Counter.main
     , example "Engine" Engine.main

--- a/copilot-verifier/examples/Copilot/Verifier/Examples/Array.hs
+++ b/copilot-verifier/examples/Copilot/Verifier/Examples/Array.hs
@@ -1,0 +1,38 @@
+--------------------------------------------------------------------------------
+-- Copyright © 2019 National Institute of Aerospace / Galois, Inc.
+--------------------------------------------------------------------------------
+
+-- | This is a simple example for arrays. As a program, it does not make much
+-- sense, however it shows of the features of arrays nicely.
+
+-- | Enable compiler extension for type-level data, necesary for the array
+-- length.
+
+{-# LANGUAGE RebindableSyntax #-}
+{-# LANGUAGE DataKinds        #-}
+
+module Copilot.Verifier.Examples.Array where
+
+import Language.Copilot
+import Copilot.Compile.C99
+import Copilot.Verifier (verify)
+
+-- Lets define an array of length 2.
+-- Make the buffer of the streams 3 elements long.
+arr :: Stream (Array 2 Bool)
+arr = [ array [True, False]
+      , array [True, True]
+      , array [False, False]] ++ arr
+
+spec :: Spec
+spec = do
+  -- A trigger that fires 'func' when the first element of 'arr' is True.
+  -- It passes the current value of arr as an argument.
+  -- The prototype of 'func' would be:
+  -- void func (int8_t arg[3]);
+  trigger "func" (arr .!! 0) [arg arr]
+
+-- Compile the spec
+main :: IO ()
+main = reify spec >>= verify mkDefaultCSettings [] "array"
+-- main = interpret 30 spec


### PR DESCRIPTION
See `Note [Arrays]`, which describes how this works. Fixes #7.

While I was in town, I also performed some cleanup of the way that `bool`s are handled in `copilot-verifier`. See `Note [How LLVM represents bool]`.

I've marked this as a draft for the time being, as I've needed to incorporate an experimental workaround for Copilot-Language/copilot#276 in order to make the test case work. It's unclear if this is the approach that we actually want to go with long-term.