### PR TITLE
Support structs

### DIFF
--- a/copilot-verifier/copilot-verifier.cabal
+++ b/copilot-verifier/copilot-verifier.cabal
@@ -42,7 +42,7 @@ common bldflags
     llvm-pretty,
     mtl,
     panic >= 0.3,
-    parameterized-utils >= 1.0.8 && < 2.2,
+    parameterized-utils >= 2.1.4 && < 2.2,
     prettyprinter >= 1.7.0,
     text,
     transformers,
@@ -71,6 +71,7 @@ library copilot-verifier-examples
     Copilot.Verifier.Examples.Counter
     Copilot.Verifier.Examples.Engine
     Copilot.Verifier.Examples.Heater
+    Copilot.Verifier.Examples.Structs
     Copilot.Verifier.Examples.Voting
 
 executable verify-examples

--- a/copilot-verifier/examples/Copilot/Verifier/Examples.hs
+++ b/copilot-verifier/examples/Copilot/Verifier/Examples.hs
@@ -13,6 +13,7 @@ import qualified Copilot.Verifier.Examples.Clock   as Clock
 import qualified Copilot.Verifier.Examples.Counter as Counter
 import qualified Copilot.Verifier.Examples.Engine  as Engine
 import qualified Copilot.Verifier.Examples.Heater  as Heater
+import qualified Copilot.Verifier.Examples.Structs as Structs
 import qualified Copilot.Verifier.Examples.Voting  as Voting
 
 allExamples :: Map (CI Text) (IO ())
@@ -23,6 +24,7 @@ allExamples = Map.fromList
     , example "Counter" Counter.main
     , example "Engine" Engine.main
     , example "Heater" Heater.main
+    , example "Structs" Structs.main
     , example "Voting" Voting.main
     ]
   where

--- a/copilot-verifier/examples/Copilot/Verifier/Examples/Structs.hs
+++ b/copilot-verifier/examples/Copilot/Verifier/Examples/Structs.hs
@@ -1,0 +1,88 @@
+-- | An example showing the usage of the What4 backend in copilot-theorem for
+-- structs and arrays. Particular focus is on nested structs.
+-- For general usage of structs, refer to the general structs example.
+
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE NoImplicitPrelude #-}
+module Copilot.Verifier.Examples.Structs where
+
+import Control.Monad (void, forM_)
+
+import Language.Copilot
+import Copilot.Compile.C99
+import Copilot.Theorem.What4
+import Copilot.Verifier (verify)
+
+
+-- | Definition for `Volts`.
+data Volts = Volts
+  { numVolts :: Field "numVolts" Word16
+  , flag     :: Field "flag"     Bool
+  }
+
+-- | `Struct` instance for `Volts`.
+instance Struct Volts where
+  typename _ = "volts"
+  toValues vlts = [ Value Word16 (numVolts vlts)
+                  , Value Bool   (flag vlts)
+                  ]
+
+-- | `Volts` instance for `Typed`.
+instance Typed Volts where
+  typeOf = Struct (Volts (Field 0) (Field False))
+
+data Battery = Battery
+  { temp  :: Field "temp"  Word16
+  , volts :: Field "volts" (Array 10 Volts)
+  , other :: Field "other" (Array 10 (Array 5 Word32))
+  }
+
+-- | `Battery` instance for `Struct`.
+instance Struct Battery where
+  typename _ = "battery"
+  toValues battery = [ Value typeOf (temp battery)
+                     , Value typeOf (volts battery)
+                     , Value typeOf (other battery)
+                     ]
+
+-- | `Battery` instance for `Typed`. Note that `undefined` is used as an
+-- argument to `Field`. This argument is never used, so `undefined` will never
+-- throw an error.
+instance Typed Battery where
+  typeOf = Struct (Battery (Field 0) (Field undefined) (Field undefined))
+
+spec :: Spec
+spec = do
+  let battery :: Stream Battery
+      battery = extern "battery" Nothing
+
+  -- Check equality, indexing into nested structs and arrays. Note that this is
+  -- trivial by equality.
+  void $ prop "Example 1" $ forall $
+    (((battery#volts) .!! 0)#numVolts) == (((battery#volts) .!! 0)#numVolts)
+
+  -- Same as previous example, but get a different array index (so should be
+  -- false).
+  void $ prop "Example 2" $ forall $
+    (((battery#other) .!! 2) .!! 3) == (((battery#other) .!! 2) .!! 4)
+
+  -- Same as previous example, but in trigger form
+  trigger "otherTrig" ((((battery#other) .!! 2) .!! 3) == (((battery#other) .!! 2) .!! 4))
+                      [arg battery]
+
+main :: IO ()
+main = do
+  spec' <- reify spec
+
+  -- Use Z3 to prove the properties.
+  results <- prove Z3 spec'
+
+  -- Print the results.
+  forM_ results $ \(nm, res) -> do
+    putStr $ nm <> ": "
+    case res of
+      Valid   -> putStrLn "valid"
+      Invalid -> putStrLn "invalid"
+      Unknown -> putStrLn "unknown"
+
+  verify mkDefaultCSettings [] "structs" spec'


### PR DESCRIPTION
This relies on a somewhat non-trivial codegen change on the `copilot` side that makes struct-typed arguments in trigger functions passed by reference, not by value (see GaloisInc/copilot-1#5). Doing so makes it much more predictable what shape the arguments will take on in LLVM (see `Note [Arrays and structs]`, which was previously `Note [Arrays]`). Once this change is in place, supporting arrays proves quite straightforward, as it mirrors the codepaths for arrays quite closely.

Fixes #9.