### PR TITLE
Add test cases for floating-point and integral operations

### DIFF
--- a/copilot-verifier/copilot-verifier.cabal
+++ b/copilot-verifier/copilot-verifier.cabal
@@ -70,7 +70,9 @@ library copilot-verifier-examples
     Copilot.Verifier.Examples.Clock
     Copilot.Verifier.Examples.Counter
     Copilot.Verifier.Examples.Engine
+    Copilot.Verifier.Examples.FPOps
     Copilot.Verifier.Examples.Heater
+    Copilot.Verifier.Examples.IntOps
     Copilot.Verifier.Examples.Structs
     Copilot.Verifier.Examples.Voting
     Copilot.Verifier.Examples.WCV

--- a/copilot-verifier/examples/Copilot/Verifier/Examples.hs
+++ b/copilot-verifier/examples/Copilot/Verifier/Examples.hs
@@ -12,7 +12,9 @@ import qualified Copilot.Verifier.Examples.Arith   as Arith
 import qualified Copilot.Verifier.Examples.Clock   as Clock
 import qualified Copilot.Verifier.Examples.Counter as Counter
 import qualified Copilot.Verifier.Examples.Engine  as Engine
+import qualified Copilot.Verifier.Examples.FPOps   as FPOps
 import qualified Copilot.Verifier.Examples.Heater  as Heater
+import qualified Copilot.Verifier.Examples.IntOps  as IntOps
 import qualified Copilot.Verifier.Examples.Structs as Structs
 import qualified Copilot.Verifier.Examples.Voting  as Voting
 import qualified Copilot.Verifier.Examples.WCV     as WCV
@@ -24,7 +26,9 @@ allExamples = Map.fromList
     , example "Clock" Clock.main
     , example "Counter" Counter.main
     , example "Engine" Engine.main
+    , example "FPOps" FPOps.main
     , example "Heater" Heater.main
+    , example "IntOps" IntOps.main
     , example "Structs" Structs.main
     , example "Voting" Voting.main
     , example "WCV"    WCV.main

--- a/copilot-verifier/examples/Copilot/Verifier/Examples/FPOps.hs
+++ b/copilot-verifier/examples/Copilot/Verifier/Examples/FPOps.hs
@@ -1,0 +1,72 @@
+{-# LANGUAGE NoImplicitPrelude #-}
+module Copilot.Verifier.Examples.FPOps where
+
+import Copilot.Compile.C99 (mkDefaultCSettings)
+import qualified Copilot.Language.Stream as Copilot
+import Copilot.Verifier (verify)
+import Language.Copilot
+import qualified Prelude as P
+
+spec :: Spec
+spec = do
+  let stream :: Stream Double
+      stream = extern "stream" Nothing
+
+  triggerOp1 "abs" abs stream
+  -- Currently fails due to https://github.com/GaloisInc/copilot-verifier/issues/14
+  -- triggerOp1 "signum" signum stream
+  triggerOp1 "recip" recip stream
+  triggerOp1 "exp" exp stream
+  triggerOp1 "sqrt" sqrt stream
+  triggerOp1 "log" log stream
+  triggerOp1 "sin" sin stream
+  triggerOp1 "tan" tan stream
+  triggerOp1 "cos" cos stream
+  triggerOp1 "asin" asin stream
+  triggerOp1 "atan" atan stream
+  triggerOp1 "acos" acos stream
+  triggerOp1 "sinh" sinh stream
+  triggerOp1 "tanh" tanh stream
+  triggerOp1 "cosh" cosh stream
+  triggerOp1 "asinh" asinh stream
+  triggerOp1 "atanh" atanh stream
+  triggerOp1 "acosh" acosh stream
+  triggerOp1 "ceiling" Copilot.ceiling stream
+  triggerOp1 "floor" Copilot.floor stream
+
+  triggerOp2 "add" (+) stream
+  triggerOp2 "sub" (-) stream
+  triggerOp2 "mul" (*) stream
+  triggerOp2 "div" (/) stream
+  triggerOp2 "pow" (**) stream
+  triggerOp2 "logBase" logBase stream
+  triggerOp2 "atan2" Copilot.atan2 stream
+
+triggerOp1 :: String ->
+              (Stream Double -> Stream Double) ->
+              Stream Double ->
+              Spec
+triggerOp1 name op stream =
+  trigger (name P.++ "Trigger") (testOp1 op stream) [arg stream]
+
+triggerOp2 :: String ->
+              (Stream Double -> Stream Double -> Stream Double) ->
+              Stream Double ->
+              Spec
+triggerOp2 name op stream =
+  trigger (name P.++ "Trigger") (testOp2 op stream) [arg stream]
+
+testOp1 :: (Stream Double -> Stream Double) -> Stream Double -> Stream Bool
+testOp1 op stream =
+  -- NB: Use (>=) rather than (==) here, as floating-point equality gets weird
+  -- due to NaNs.
+  op stream >= op stream
+
+testOp2 :: (Stream Double -> Stream Double -> Stream Double) -> Stream Double -> Stream Bool
+testOp2 op stream =
+  op stream stream >= op stream stream
+
+main :: IO ()
+main = do
+  spec' <- reify spec
+  verify mkDefaultCSettings [] "fpOps" spec'

--- a/copilot-verifier/examples/Copilot/Verifier/Examples/IntOps.hs
+++ b/copilot-verifier/examples/Copilot/Verifier/Examples/IntOps.hs
@@ -1,0 +1,63 @@
+{-# LANGUAGE NoImplicitPrelude #-}
+module Copilot.Verifier.Examples.IntOps where
+
+import Copilot.Compile.C99 (mkDefaultCSettings)
+import Copilot.Verifier (verify)
+import Language.Copilot
+import qualified Prelude as P
+
+spec :: Spec
+spec = do
+  let stream :: Stream Int16
+      stream = extern "stream" Nothing
+
+      shiftBy :: Stream Int16
+      shiftBy = extern "shiftBy" Nothing
+
+  _ <- prop "nonzero" (forall (stream /= 0))
+  _ <- prop "shiftByBits" (forall (0 <= shiftBy && shiftBy < 16))
+
+  triggerOp1 "abs" abs stream
+  -- Currently fails due to https://github.com/GaloisInc/copilot-verifier/issues/14
+  -- triggerOp1 "signum" signum stream
+  triggerOp1 "bwNot" complement stream
+
+  triggerOp2 "add" (+) stream stream
+  triggerOp2 "sub" (-) stream stream
+  triggerOp2 "mul" (*) stream stream
+  triggerOp2 "mod" mod stream stream
+  triggerOp2 "div" div stream stream
+  triggerOp2 "bwAnd" (.&.) stream stream
+  triggerOp2 "bwOr" (.|.) stream stream
+  triggerOp2 "bwXor" (.^.) stream stream
+  triggerOp2 "bwShiftL" (.<<.) stream shiftBy
+  triggerOp2 "bwShiftR" (.>>.) stream shiftBy
+
+triggerOp1 :: String ->
+              (Stream Int16 -> Stream Int16) ->
+              Stream Int16 ->
+              Spec
+triggerOp1 name op stream =
+  trigger (name P.++ "Trigger") (testOp1 op stream) [arg stream]
+
+triggerOp2 :: String ->
+              (Stream Int16 -> Stream Int16 -> Stream Int16) ->
+              Stream Int16 -> Stream Int16 ->
+              Spec
+triggerOp2 name op stream1 stream2 =
+  trigger (name P.++ "Trigger") (testOp2 op stream1 stream2) [arg stream1, arg stream2]
+
+testOp1 :: (Stream Int16 -> Stream Int16) -> Stream Int16 -> Stream Bool
+testOp1 op stream =
+  op stream == op stream
+
+testOp2 :: (Stream Int16 -> Stream Int16 -> Stream Int16) ->
+           Stream Int16 -> Stream Int16 ->
+           Stream Bool
+testOp2 op stream1 stream2 =
+  op stream1 stream2 == op stream1 stream2
+
+main :: IO ()
+main = do
+  spec' <- reify spec
+  verify mkDefaultCSettings ["nonzero", "shiftByBits"] "intOps" spec'


### PR DESCRIPTION
One operation—`signum`—currently fails due to #14.

Addresses one part of #13.