### PR TITLE
Control verbosity more in logging

### DIFF
--- a/copilot-verifier/copilot-verifier.cabal
+++ b/copilot-verifier/copilot-verifier.cabal
@@ -86,6 +86,7 @@ executable verify-examples
   main-is: VerifyExamples.hs
   build-depends:
     case-insensitive,
+    copilot-verifier,
     copilot-verifier-examples,
     optparse-applicative
 
@@ -96,6 +97,7 @@ test-suite copilot-verifier-test
   hs-source-dirs: test
   build-depends:
     case-insensitive,
+    copilot-verifier,
     copilot-verifier-examples,
     tasty >= 0.10,
     tasty-hunit >= 0.10

--- a/copilot-verifier/examples/Copilot/Verifier/Examples.hs
+++ b/copilot-verifier/examples/Copilot/Verifier/Examples.hs
@@ -7,6 +7,7 @@ import qualified Data.Map as Map
 import Data.Map (Map)
 import Data.Text (Text)
 
+import Copilot.Verifier (Verbosity)
 import qualified Copilot.Verifier.Examples.Array   as Array
 import qualified Copilot.Verifier.Examples.Arith   as Arith
 import qualified Copilot.Verifier.Examples.Clock   as Clock
@@ -19,19 +20,19 @@ import qualified Copilot.Verifier.Examples.Structs as Structs
 import qualified Copilot.Verifier.Examples.Voting  as Voting
 import qualified Copilot.Verifier.Examples.WCV     as WCV
 
-allExamples :: Map (CI Text) (IO ())
-allExamples = Map.fromList
-    [ example "Array" Array.main
-    , example "Arith" Arith.main
-    , example "Clock" Clock.main
-    , example "Counter" Counter.main
-    , example "Engine" Engine.main
-    , example "FPOps" FPOps.main
-    , example "Heater" Heater.main
-    , example "IntOps" IntOps.main
-    , example "Structs" Structs.main
-    , example "Voting" Voting.main
-    , example "WCV"    WCV.main
+allExamples :: Verbosity -> Map (CI Text) (IO ())
+allExamples verb = Map.fromList
+    [ example "Array" (Array.verifySpec verb)
+    , example "Arith" (Arith.verifySpec verb)
+    , example "Clock" (Clock.verifySpec verb)
+    , example "Counter" (Counter.verifySpec verb)
+    , example "Engine" (Engine.verifySpec verb)
+    , example "FPOps" (FPOps.verifySpec verb)
+    , example "Heater" (Heater.verifySpec verb)
+    , example "IntOps" (IntOps.verifySpec verb)
+    , example "Structs" (Structs.verifySpec verb)
+    , example "Voting" (Voting.verifySpec verb)
+    , example "WCV" (WCV.verifySpec verb)
     ]
   where
     example :: Text -> IO () -> (CI Text, IO ())

--- a/copilot-verifier/examples/Copilot/Verifier/Examples/Arith.hs
+++ b/copilot-verifier/examples/Copilot/Verifier/Examples/Arith.hs
@@ -3,9 +3,12 @@
 
 module Copilot.Verifier.Examples.Arith where
 
+import Control.Monad (when)
+import qualified Prelude as P
+
 import Language.Copilot
 import Copilot.Compile.C99
-import Copilot.Verifier (verify)
+import Copilot.Verifier (Verbosity(..), verifyWithVerbosity)
 import Copilot.Theorem.What4 (prove, Solver(..))
 
 -- The largest unsigned 32-bit prime
@@ -36,11 +39,12 @@ multRingSpec = do
   acc :: Stream Word32
   acc = [1] ++ unsafeCast ((cast acc * cast clamp) `mod` (cast lastPrime :: Stream Word64))
 
-main :: IO ()
-main =
+verifySpec :: Verbosity -> IO ()
+verifySpec verb =
   do s <- reify multRingSpec
      r <- prove Z3 s
-     print r
-     verify mkDefaultCSettings ["reduced"] "multRingSpec" s
+     when (verb P.== Noisy) $
+       print r
+     verifyWithVerbosity verb mkDefaultCSettings ["reduced"] "multRingSpec" s
 
---main = interpret 10 engineMonitor
+--verifySpec _ = interpret 10 engineMonitor

--- a/copilot-verifier/examples/Copilot/Verifier/Examples/Array.hs
+++ b/copilot-verifier/examples/Copilot/Verifier/Examples/Array.hs
@@ -15,7 +15,7 @@ module Copilot.Verifier.Examples.Array where
 
 import Language.Copilot
 import Copilot.Compile.C99
-import Copilot.Verifier (verify)
+import Copilot.Verifier (Verbosity, verifyWithVerbosity)
 
 -- Lets define an array of length 2.
 -- Make the buffer of the streams 3 elements long.
@@ -33,6 +33,6 @@ spec = do
   trigger "func" (arr .!! 0) [arg arr]
 
 -- Compile the spec
-main :: IO ()
-main = reify spec >>= verify mkDefaultCSettings [] "array"
--- main = interpret 30 spec
+verifySpec :: Verbosity -> IO ()
+verifySpec verb = reify spec >>= verifyWithVerbosity verb mkDefaultCSettings [] "array"
+-- verifySpec _ = interpret 30 spec

--- a/copilot-verifier/examples/Copilot/Verifier/Examples/Clock.hs
+++ b/copilot-verifier/examples/Copilot/Verifier/Examples/Clock.hs
@@ -7,11 +7,12 @@
 
 module Copilot.Verifier.Examples.Clock where
 
-import qualified Prelude as P ()
+import Control.Monad (when)
+import qualified Prelude as P
 
 import Language.Copilot
 import Copilot.Compile.C99
-import Copilot.Verifier (verify)
+import Copilot.Verifier (Verbosity(..), verifyWithVerbosity)
 import Copilot.Theorem.What4 (prove, Solver(..))
 
 -- | We need to force a type for the argument of `period`.
@@ -34,8 +35,10 @@ spec = do
   trigger "clksHigh" (clkStream && clkStream') []
 
 
-main :: IO ()
-main =
+verifySpec :: Verbosity -> IO ()
+verifySpec verb =
   do s <- reify spec
-     print =<< prove Z3 s
-     verify mkDefaultCSettings [] "clock" s
+     r <- prove Z3 s
+     when (verb P.== Noisy) $
+       print r
+     verifyWithVerbosity verb mkDefaultCSettings [] "clock" s

--- a/copilot-verifier/examples/Copilot/Verifier/Examples/Counter.hs
+++ b/copilot-verifier/examples/Copilot/Verifier/Examples/Counter.hs
@@ -8,9 +8,12 @@
 
 module Copilot.Verifier.Examples.Counter where
 
+import Control.Monad (when)
+import qualified Prelude as P
+
 import Language.Copilot
 import Copilot.Compile.C99
-import Copilot.Verifier (verify)
+import Copilot.Verifier (Verbosity(..), verifyWithVerbosity)
 import Copilot.Theorem.What4 (prove, Solver(..))
 
 -- A resettable counter
@@ -41,9 +44,11 @@ spec =
                                 (bytecounter == bytecounter2)))
      trigger "counter" true [arg $ bytecounter, arg $ bytecounter2]
 
-main :: IO ()
--- main = interpret 1280 spec
-main =
+verifySpec :: Verbosity -> IO ()
+-- verifSpec _ = interpret 1280 spec
+verifySpec verb =
   do s <- reify spec
-     print =<< prove Z3 s
-     verify mkDefaultCSettings ["range", "range2"] "counter" s
+     r <- prove Z3 s
+     when (verb P.== Noisy) $
+       print r
+     verifyWithVerbosity verb mkDefaultCSettings ["range", "range2"] "counter" s

--- a/copilot-verifier/examples/Copilot/Verifier/Examples/Engine.hs
+++ b/copilot-verifier/examples/Copilot/Verifier/Examples/Engine.hs
@@ -10,7 +10,7 @@ module Copilot.Verifier.Examples.Engine where
 
 import Language.Copilot
 import Copilot.Compile.C99
-import Copilot.Verifier (verify)
+import Copilot.Verifier (Verbosity, verifyWithVerbosity)
 
 import qualified Prelude as P
 
@@ -37,6 +37,6 @@ engineMonitor = do
   zero   = Just $ repeat (0 :: Word8)
   cooler = Just $ [True, True] P.++ repeat False
 
-main :: IO ()
-main = reify engineMonitor >>= verify mkDefaultCSettings [] "engine"
---main = interpret 10 engineMonitor
+verifySpec :: Verbosity -> IO ()
+verifySpec verb = reify engineMonitor >>= verifyWithVerbosity verb mkDefaultCSettings [] "engine"
+--verifySpec _ = interpret 10 engineMonitor

--- a/copilot-verifier/examples/Copilot/Verifier/Examples/FPOps.hs
+++ b/copilot-verifier/examples/Copilot/Verifier/Examples/FPOps.hs
@@ -5,7 +5,7 @@ module Copilot.Verifier.Examples.FPOps where
 
 import Copilot.Compile.C99 (mkDefaultCSettings)
 import qualified Copilot.Language.Stream as Copilot
-import Copilot.Verifier (verify)
+import Copilot.Verifier (Verbosity, verifyWithVerbosity)
 import Data.Proxy (Proxy(..))
 import Language.Copilot
 import qualified Prelude as P
@@ -80,7 +80,7 @@ testOp2 :: (RealFloat a, Typed a) =>
 testOp2 op stream =
   op stream stream >= op stream stream
 
-main :: IO ()
-main = do
+verifySpec :: Verbosity -> IO ()
+verifySpec verb = do
   spec' <- reify spec
-  verify mkDefaultCSettings [] "fpOps" spec'
+  verifyWithVerbosity verb mkDefaultCSettings [] "fpOps" spec'

--- a/copilot-verifier/examples/Copilot/Verifier/Examples/Heater.hs
+++ b/copilot-verifier/examples/Copilot/Verifier/Examples/Heater.hs
@@ -14,7 +14,7 @@ import Copilot.Compile.C99
 --import Copilot.Core.PrettyDot (prettyPrintDot)
 --import Copilot.Language.Prelude
 
-import Copilot.Verifier (verify)
+import Copilot.Verifier (Verbosity, verifyWithVerbosity)
 
 import Prelude ()
 
@@ -36,8 +36,8 @@ spec = do
   trigger "heatoff" (sumTemp > (21*fromIntegral window)) [arg sumTemp]
 
 -- Compile the spec
-main :: IO ()
-main = reify spec >>= verify mkDefaultCSettings [] "heater"
+verifySpec :: Verbosity -> IO ()
+verifySpec verb = reify spec >>= verifyWithVerbosity verb mkDefaultCSettings [] "heater"
 {-
   do spec' <- reify spec
      putStrLn $ prettyPrintDot spec'

--- a/copilot-verifier/examples/Copilot/Verifier/Examples/IntOps.hs
+++ b/copilot-verifier/examples/Copilot/Verifier/Examples/IntOps.hs
@@ -2,7 +2,7 @@
 module Copilot.Verifier.Examples.IntOps where
 
 import Copilot.Compile.C99 (mkDefaultCSettings)
-import Copilot.Verifier (verify)
+import Copilot.Verifier (Verbosity, verifyWithVerbosity)
 import Language.Copilot
 import qualified Prelude as P
 
@@ -56,7 +56,7 @@ testOp2 :: (Stream Int16 -> Stream Int16 -> Stream Int16) ->
 testOp2 op stream1 stream2 =
   op stream1 stream2 == op stream1 stream2
 
-main :: IO ()
-main = do
+verifySpec :: Verbosity -> IO ()
+verifySpec verb = do
   spec' <- reify spec
-  verify mkDefaultCSettings ["nonzero", "shiftByBits"] "intOps" spec'
+  verifyWithVerbosity verb mkDefaultCSettings ["nonzero", "shiftByBits"] "intOps" spec'

--- a/copilot-verifier/examples/Copilot/Verifier/Examples/Voting.hs
+++ b/copilot-verifier/examples/Copilot/Verifier/Examples/Voting.hs
@@ -10,7 +10,7 @@ module Copilot.Verifier.Examples.Voting where
 
 import Language.Copilot
 import Copilot.Compile.C99
-import Copilot.Verifier (verify)
+import Copilot.Verifier (Verbosity, verifyWithVerbosity)
 
 vote :: Spec
 vote = do
@@ -57,6 +57,6 @@ vote = do
     z = [1] ++ z + 1
 -}
 
-main :: IO ()
---main = interpret 30 vote
-main = reify vote >>= verify mkDefaultCSettings [] "voting"
+verifySpec :: Verbosity -> IO ()
+--verifySpec _ = interpret 30 vote
+verifySpec verb = reify vote >>= verifyWithVerbosity verb mkDefaultCSettings [] "voting"

--- a/copilot-verifier/examples/Copilot/Verifier/Examples/WCV.hs
+++ b/copilot-verifier/examples/Copilot/Verifier/Examples/WCV.hs
@@ -11,7 +11,7 @@ module Copilot.Verifier.Examples.WCV where
 import Language.Copilot
 import qualified Copilot.Theorem.What4 as CT
 import Copilot.Compile.C99
-import Copilot.Verifier (verify)
+import Copilot.Verifier (Verbosity, verifyWithVerbosity)
 
 import qualified Prelude as P
 import Data.Foldable (forM_)
@@ -173,10 +173,10 @@ spec = do
   -- Monad.void $ prop "3d" (forall $ (wcv tep s sz v vz)    == (wcv tep (neg s) (-sz) (neg v) (-vz)))
   trigger "well_clear_violation" (wcv tep s sz v vz) []
 
-main :: IO ()
-main = do
+verifySpec :: Verbosity -> IO ()
+verifySpec verb = do
   spec' <- reify spec
-  verify mkDefaultCSettings [] "wcv" spec'
+  verifyWithVerbosity verb mkDefaultCSettings [] "wcv" spec'
 
 {-
   -- Use Z3 to prove the properties.

--- a/copilot-verifier/exe/VerifyExamples.hs
+++ b/copilot-verifier/exe/VerifyExamples.hs
@@ -12,6 +12,7 @@ import Data.Text (Text)
 import Data.Traversable (for)
 import Options.Applicative
 
+import Copilot.Verifier (Verbosity(..))
 import Copilot.Verifier.Examples (allExamples)
 
 newtype Options = Options
@@ -38,7 +39,7 @@ verifyExamples :: Options -> IO ()
 verifyExamples Options{examples} = do
   -- Check that all requested examples exist
   examplesWithMain <- for examples $ \example ->
-    case Map.lookup example allExamples of
+    case Map.lookup example (allExamples Noisy) of
       Just m  -> pure (example, m)
       Nothing -> fail $ "No example named " ++ Text.unpack (CI.original example)
 

--- a/copilot-verifier/src/Copilot/Verifier/Log.hs
+++ b/copilot-verifier/src/Copilot/Verifier/Log.hs
@@ -57,29 +57,29 @@ copilotTag = "copilot-verifier"
 -- copilotFail :: Text -> SayWhat
 -- copilotFail = SayWhat Fail copilotTag
 
-copilotOK :: Text -> SayWhat
-copilotOK = SayWhat OK copilotTag
+copilotSimply :: Text -> SayWhat
+copilotSimply = SayWhat Simply copilotTag
 
 -- copilotWarn :: Text -> SayWhat
 -- copilotWarn = SayWhat Warn copilotTag
 
 copilotLogMessageToSayWhat :: CopilotLogMessage -> SayWhat
 copilotLogMessageToSayWhat (GeneratedCFile csrc) =
-  copilotOK $ "Generated " <> T.pack (show csrc)
+  copilotSimply $ "Generated " <> T.pack (show csrc)
 copilotLogMessageToSayWhat (CompiledBitcodeFile prefix bcFile) =
-  copilotOK $ "Compiled " <> T.pack prefix <> " into " <> T.pack bcFile
+  copilotSimply $ "Compiled " <> T.pack prefix <> " into " <> T.pack bcFile
 copilotLogMessageToSayWhat TranslatedToCrucible =
-  copilotOK "Translated bitcode into Crucible"
+  copilotSimply "Translated bitcode into Crucible"
 copilotLogMessageToSayWhat GeneratingProofState =
-  copilotOK "Generating proof state data"
+  copilotSimply "Generating proof state data"
 copilotLogMessageToSayWhat (ComputingConditions step) =
-  copilotOK $ "Computing " <> describeVerificationStep step <> " verification conditions"
+  copilotSimply $ "Computing " <> describeVerificationStep step <> " verification conditions"
 copilotLogMessageToSayWhat (ProvingConditions step) =
-  copilotOK $ "Proving " <> describeVerificationStep step <> " verification conditions"
+  copilotSimply $ "Proving " <> describeVerificationStep step <> " verification conditions"
 copilotLogMessageToSayWhat AllGoalsProved =
-  copilotOK "All obligations proved by concrete simplification"
+  copilotSimply "All obligations proved by concrete simplification"
 copilotLogMessageToSayWhat (OnlySomeGoalsProved numProvedGoals numTotalGoals) =
-  copilotOK $ T.unwords
+  copilotSimply $ T.unwords
     [ "Proved", T.pack (show numProvedGoals)
     , "of"
     , T.pack (show numTotalGoals), "total goals"

--- a/copilot-verifier/test/Test.hs
+++ b/copilot-verifier/test/Test.hs
@@ -6,10 +6,11 @@ import qualified Data.Text as Text
 import Test.Tasty
 import Test.Tasty.HUnit
 
+import Copilot.Verifier (Verbosity(..))
 import Copilot.Verifier.Examples (allExamples)
 
 main :: IO ()
 main = defaultMain $
   testGroup "copilot-verifier-examples tests" $
     map (\(name, action) -> testCase (Text.unpack (CI.original name)) action)
-        (Map.toAscList allExamples)
+        (Map.toAscList (allExamples Quiet))


### PR DESCRIPTION
This adds a new `Verbosity` data type and a corresponding `verifyWithVerbosity` function that controls whether `copilot-verifier` should produce logs or not. We want to make the `Verbosity` be `Quiet` primarily in the test suite so that the diagnostic output does not drown out the output from `tasty`.

This is a first step towards the first bullet point in #13.