### PR TITLE
Fix handling of nested structs

### DIFF
--- a/copilot-verifier/copilot-verifier.cabal
+++ b/copilot-verifier/copilot-verifier.cabal
@@ -79,6 +79,7 @@ library copilot-verifier-examples
     Copilot.Verifier.Examples.ShouldFail.Partial.SubSignedWrap
 
     Copilot.Verifier.Examples.ShouldPass.Array
+    Copilot.Verifier.Examples.ShouldPass.ArrayOfStructs
     Copilot.Verifier.Examples.ShouldPass.Arith
     Copilot.Verifier.Examples.ShouldPass.Clock
     Copilot.Verifier.Examples.ShouldPass.Counter

--- a/copilot-verifier/examples/Copilot/Verifier/Examples.hs
+++ b/copilot-verifier/examples/Copilot/Verifier/Examples.hs
@@ -21,6 +21,7 @@ import qualified Copilot.Verifier.Examples.ShouldFail.Partial.ShiftLTooLarge   a
 import qualified Copilot.Verifier.Examples.ShouldFail.Partial.ShiftRTooLarge   as Fail.ShiftRTooLarge
 import qualified Copilot.Verifier.Examples.ShouldFail.Partial.SubSignedWrap    as Fail.SubSignedWrap
 import qualified Copilot.Verifier.Examples.ShouldPass.Array                    as Array
+import qualified Copilot.Verifier.Examples.ShouldPass.ArrayOfStructs           as ArrayOfStructs
 import qualified Copilot.Verifier.Examples.ShouldPass.Arith                    as Arith
 import qualified Copilot.Verifier.Examples.ShouldPass.Clock                    as Clock
 import qualified Copilot.Verifier.Examples.ShouldPass.Counter                  as Counter
@@ -58,6 +59,7 @@ shouldFailExamples verb = Map.fromList
 shouldPassExamples :: Verbosity -> Map (CI Text) (IO ())
 shouldPassExamples verb = Map.fromList
     [ example "Array" (Array.verifySpec verb)
+    , example "ArrayOfStructs" (ArrayOfStructs.verifySpec verb)
     , example "Arith" (Arith.verifySpec verb)
     , example "Clock" (Clock.verifySpec verb)
     , example "Counter" (Counter.verifySpec verb)

--- a/copilot-verifier/examples/Copilot/Verifier/Examples/ShouldPass/ArrayOfStructs.hs
+++ b/copilot-verifier/examples/Copilot/Verifier/Examples/ShouldPass/ArrayOfStructs.hs
@@ -1,0 +1,29 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE NoImplicitPrelude #-}
+module Copilot.Verifier.Examples.ShouldPass.ArrayOfStructs where
+
+import Copilot.Compile.C99
+import Copilot.Verifier ( Verbosity, VerifierOptions(..)
+                        , defaultVerifierOptions, verifyWithOptions )
+import Language.Copilot
+
+data S = S { field :: Field "field" Int16 }
+
+instance Struct S where
+  typename _ = "s"
+  toValues s = [Value Int16 (field s)]
+
+instance Typed S where
+  typeOf = Struct (S (Field 0))
+
+spec :: Spec
+spec = trigger "f" ((stream .!! 0)#field == 27) [arg stream]
+  where
+    stream :: Stream (Array 2 S)
+    stream = [array [S (Field 27), S (Field 42)]] ++ stream
+
+verifySpec :: Verbosity -> IO ()
+verifySpec verb = do
+  spec' <- reify spec
+  verifyWithOptions defaultVerifierOptions{verbosity = verb}
+                    mkDefaultCSettings [] "arrayOfStructs" spec'

--- a/copilot-verifier/src/Copilot/Verifier.hs
+++ b/copilot-verifier/src/Copilot/Verifier.hs
@@ -1004,10 +1004,10 @@ copilotTypeToLLVMType = loop
       let len = fromIntegral (tylength t0) in
       L.Array len (copilotTypeToLLVMTypeBool8 tp)
     loop (CT.Struct v) =
-      L.Struct (map val (CT.toValues v))
-
-    val :: forall t. CT.Value t -> L.Type
-    val (CT.Value tp _) = copilotTypeToLLVMTypeBool8 tp
+      -- NB: Don't use L.Struct here. That represents a literal, unnamed
+      -- struct, but all of the structs used in a copilot-c99 program are
+      -- named structs. As such, we must identify the struct by its alias.
+      L.Alias (copilotStructIdent v)
 
 -- | Like 'copilotTypeToLLVMType', except that 'CT.Bool's are assumed to be
 -- eight bits, not one bit. See @Note [How LLVM represents bool]@.
@@ -1018,8 +1018,8 @@ copilotTypeToLLVMTypeBool8 CT.Bool = L.PrimType (L.Integer 8)
 copilotTypeToLLVMTypeBool8 tp = copilotTypeToLLVMType tp
 
 -- | Like 'copilotTypeToLLVMType', except that composite types (i.e.,
--- 'CT.Array's and 'CT.Struct's) are converted to 'L.PtrTo' instead of direct
--- 'L.Array's or 'L.Struct's. See @Note [Arrays and structs]@.
+-- 'CT.Array's and 'CT.Struct's) are given special treatment involving
+-- pointers. See @Note [Arrays and structs]@.
 copilotTypeToLLVMTypeCompositePtr ::
   CT.Type a ->
   L.Type


### PR DESCRIPTION
Namely, declare nested struct types using `Alias` rather than `Struct`. The latter is for literal LLVM structs, whereas we want named, top-level structs (the former).

Fixes #31.